### PR TITLE
Define unicode() for Python 3

### DIFF
--- a/ibm_storage_flocker_driver/ibm_storage_blockdevice.py
+++ b/ibm_storage_flocker_driver/ibm_storage_blockdevice.py
@@ -55,6 +55,11 @@ from ibm_storage_flocker_driver.lib.constants import (
     CONF_PARAM_HOSTNAME,
 )
 
+try:
+    unicode        # Python2
+except NameError:
+    unicode = str  # Python 3
+
 LOG = config_logger(logging.getLogger(__name__))
 PREFIX = 'API'  # log prefix
 

--- a/ibm_storage_flocker_driver/test_ibm_storage_flocker_driver.py
+++ b/ibm_storage_flocker_driver/test_ibm_storage_flocker_driver.py
@@ -22,6 +22,11 @@ from flocker.node.agents.test.test_blockdevice import (
 from ibm_storage_flocker_driver.testtools_ibm_storage_flocker_driver import \
     get_ibm_storage_blockdevice_api_for_test
 
+try:
+    unicode        # Python2
+except NameError:
+    unicode = str  # Python 3
+
 # Smallest volume to create in tests
 MIN_ALLOCATION_SIZE = int(GiB(1).to_Byte().value)
 

--- a/ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py
+++ b/ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py
@@ -42,6 +42,11 @@ from ibm_storage_flocker_driver.lib.constants import (
 )
 from ibm_storage_flocker_driver.lib import messages
 
+try:
+    unicode        # Python2
+except NameError:
+    unicode = str  # Python 3
+
 # Constants for unit testing
 UUID1_STR = '737d4ea0-28bf-11e6-b12e-68f7288f1809'
 UUID1 = UUID(UUID1_STR)


### PR DESCRIPTION
flake8 testing of https://github.com/IBM/flocker-driver on Python 3.6.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./ibm_storage_flocker_driver/ibm_storage_blockdevice.py:82:24: F821 undefined name 'unicode'
    hostname_aligned = unicode(hostname) if hostname else None
                       ^

./ibm_storage_flocker_driver/ibm_storage_blockdevice.py:158:24: F821 undefined name 'unicode'
        blockdevice_id=unicode(wwn),
                       ^

./ibm_storage_flocker_driver/ibm_storage_blockdevice.py:292:13: F821 undefined name 'unicode'
            unicode(socket.gethostname())
            ^

./ibm_storage_flocker_driver/ibm_storage_blockdevice.py:571:28: F821 undefined name 'unicode'
                hostname = unicode(hostname)
                           ^

./ibm_storage_flocker_driver/ibm_storage_blockdevice.py:592:33: F821 undefined name 'unicode'
            raise UnknownVolume(unicode(vol_obj.wwn))
                                ^

./ibm_storage_flocker_driver/ibm_storage_blockdevice.py:595:16: F821 undefined name 'unicode'
        host = unicode(host) if host else None
               ^

./ibm_storage_flocker_driver/test_ibm_storage_flocker_driver.py:40:57: F821 undefined name 'unicode'
            unknown_blockdevice_id_factory=lambda test: unicode(uuid4())
                                                        ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:65:20: F821 undefined name 'unicode'
    blockdevice_id=unicode(UUID1_STR),
                   ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:72:20: F821 undefined name 'unicode'
    blockdevice_id=unicode(UUID3_STR),
                   ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:129:28: F821 undefined name 'unicode'
            blockdevice_id=unicode(test_host_actions.MULTIPATH_OUTPUT_WWN),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:204:48: F821 undefined name 'unicode'
        self.assertTrue(driver_obj._get_volume(unicode(UUID1_STR)), BDV1)
                                               ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:207:48: F821 undefined name 'unicode'
        self.assertTrue(driver_obj._get_volume(unicode(UUID3_STR)), BDV3)
                                               ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:211:27: F821 undefined name 'unicode'
                          unicode('fack-lockdevice-id'))
                          ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:224:50: F821 undefined name 'unicode'
        self.assertTrue(driver_obj._volume_exist(unicode(UUID1_STR)))
                                                 ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:227:50: F821 undefined name 'unicode'
        self.assertTrue(driver_obj._volume_exist(unicode(UUID3_STR)))
                                                 ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:231:38: F821 undefined name 'unicode'
            driver_obj._volume_exist(unicode('fack-lockdevice-id')))
                                     ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:257:28: F821 undefined name 'unicode'
            blockdevice_id=unicode(mock_vol_obj.wwn),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:274:28: F821 undefined name 'unicode'
            blockdevice_id=unicode(test_host_actions.MULTIPATH_OUTPUT_WWN2),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:308:28: F821 undefined name 'unicode'
            blockdevice_id=unicode(UUID1_STR),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:330:28: F821 undefined name 'unicode'
            blockdevice_id=unicode(UUID1_STR),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:358:28: F821 undefined name 'unicode'
            blockdevice_id=unicode(UUID1_STR),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:381:27: F821 undefined name 'unicode'
                          unicode(UUID(UUID1_STR)))
                          ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:388:28: F821 undefined name 'unicode'
            blockdevice_id=unicode('999'),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:396:35: F821 undefined name 'unicode'
        driver_obj.destroy_volume(unicode(UUID(UUID1_STR)))
                                  ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:416:28: F821 undefined name 'unicode'
            blockdevice_id=unicode('999'),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:430:13: F821 undefined name 'unicode'
            unicode(UUID1_STR), 'fake-host')
            ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:439:13: F821 undefined name 'unicode'
            unicode(UUID1_STR), u'fake-host').attached_to
            ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:450:13: F821 undefined name 'unicode'
            unicode(UUID1_STR))
            ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:461:43: F821 undefined name 'unicode'
            self.driver_obj.detach_volume(unicode(UUID1_STR)))
                                          ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:491:32: F821 undefined name 'unicode'
                blockdevice_id=unicode(WWN1),
                               ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:493:29: F821 undefined name 'unicode'
                attached_to=unicode(HOST),
                            ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:497:32: F821 undefined name 'unicode'
                blockdevice_id=unicode(WWN2),
                               ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:499:29: F821 undefined name 'unicode'
                attached_to=unicode(HOST),
                            ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:531:28: F821 undefined name 'unicode'
            blockdevice_id=unicode(WWN2),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:544:28: F821 undefined name 'unicode'
            blockdevice_id=unicode(WWN1),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:558:28: F821 undefined name 'unicode'
            blockdevice_id=unicode(WWN1),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:565:28: F821 undefined name 'unicode'
            blockdevice_id=unicode(WWN2),
                           ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:712:50: F821 undefined name 'unicode'
        self.assertEqual(type(api._instance_id), unicode)
                                                 ^

./ibm_storage_flocker_driver/tests/test_ibm_storage_blockdevice_ut.py:720:50: F821 undefined name 'unicode'
        self.assertEqual(type(api._instance_id), unicode)
                                                 ^
```